### PR TITLE
Remove reference to triggerPin

### DIFF
--- a/DigitalCalipers.ino
+++ b/DigitalCalipers.ino
@@ -28,7 +28,6 @@ void setup() {
  
   pinMode(clockPin, INPUT);  
   pinMode(dataPin, INPUT); 
-  pinMode(triggerPin, INPUT);
   
   //We have to take the value on the RISING edge instead of FALLING
   //because it is possible that the first bit will be missed and this


### PR DESCRIPTION
triggerPin is never defined(or used) so this caused compile to fail:

```
'triggerPin' was not declared in this scope"
```
